### PR TITLE
fix(book): dynamic network.type

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -8,8 +8,11 @@ Since most of them are generated, the `src` directory's contents are excluded th
 
 ## Usage
 
-You will first need to install `uv` and `just`. Then:
+You will first need to install `uv`, `mdbook`, and `just`:
 
+`brew install uv mdbook just`
+
+Then:
 1. Generate the devnet docs by running `just generate`.
 2. Run `just serve` to start the local server.
 3. For prod, run `just build` to generate the static site.

--- a/book/gen/templates/network.md.j2
+++ b/book/gen/templates/network.md.j2
@@ -14,7 +14,7 @@ It was deployed on {{ network.deployed_on }}.
 |------------------------------------|-------|-----------------------------|--------|--------|---------|
 | L1 | {{ network.l1.name | title }}  | `{{ network.l1.chain_id }}` | - | - | - |
 {% for chain in network.l2.chains %}
-| L2 | {{ chain.name }} | `{{ chain.chain_id }}` | [View](https://github.com/ethereum-optimism/devnets/blob/main/alphanets/{{ network.name }}/{{ chain.name }}/chain.yaml) | [View](https://github.com/ethereum-optimism/devnets/blob/main/alphanets/{{ network.name }}/{{ chain.name }}/rollup.json) | [Download](https://raw.githubusercontent.com/ethereum-optimism/devnets/refs/heads/main/alphanets/{{ network.name }}/{{ chain.name }}/genesis.json)
+| L2 | {{ chain.name }} | `{{ chain.chain_id }}` | [View](https://github.com/ethereum-optimism/devnets/blob/main/{{ network.type }}s/{{ network.name }}/{{ chain.name }}/chain.yaml) | [View](https://github.com/ethereum-optimism/devnets/blob/main/{{ network.type }}s/{{ network.name }}/{{ chain.name }}/rollup.json) | [Download](https://raw.githubusercontent.com/ethereum-optimism/devnets/refs/heads/main/{{ network.type }}s/{{ network.name }}/{{ chain.name }}/genesis.json)
 {% endfor %}
 
 ## Deployment Details


### PR DESCRIPTION
**Description**

Replaces the hardcoded `alphanet` network type, which fixes links for other network types (eg. betanet "aegir-0")

**Tests**

Generated and served locally to double-check links are now correct (new and old).
