### PR TITLE
fix aegir 1 chain id

### DIFF
--- a/betanets/aegir/aegir-1/chain.yaml
+++ b/betanets/aegir/aegir-1/chain.yaml
@@ -1,5 +1,5 @@
 name: aegir-1
-chain_id: 420110002
+chain_id: 420110005
 rpc_url: https://aegir-1.optimism.io
 contracts:
   superchainDeployment:


### PR DESCRIPTION
**Description**

The chain id in this [chain.yaml](https://github.com/ethereum-optimism/devnets/blob/52d29f90fc506feb4a0ebbd26fdf157bbb14950f/betanets/aegir/aegir-1/chain.yaml#L2) was wrong.

In the [state.json](https://github.com/ethereum-optimism/devnets/blob/52d29f90fc506feb4a0ebbd26fdf157bbb14950f/betanets/aegir/op-deployer/state.json#L46) it ends with 5.

```
cast 2d 0x00000000000000000000000000000000000000000000000000000000190a5eb5
420110005
```