### PR TITLE
chore: enable flashblocks-websocket-proxy-0 service

### DIFF
--- a/betanets/eris/inventory.yaml
+++ b/betanets/eris/inventory.yaml
@@ -142,6 +142,16 @@ chains:
             - "rpc-1"
             - "snapsync-0"
             - "snapsync-1"
+      
+      - kind: "flashblocks-websocket-proxy"
+        name: "flashblocks-websocket-proxy-0"
+        spec:
+          kind: "flashblocks-websocket-proxy"
+        deps:
+          nodes:
+            - "sequencer-0"
+            - "sequencer-1"
+            - "sequencer-2"
 
       - kind: "op-conductor-mon"
         name: "op-conductor-mon"

--- a/betanets/eris/manifest.yaml
+++ b/betanets/eris/manifest.yaml
@@ -29,7 +29,7 @@ l2:
     op-geth:
       version: op-geth/v1.101511.0-rc.1
     op-reth:
-      version: op-reth/v1.4.3
+      version: op-reth/v1.4.8
     op-proposer:
       version: op-proposer/v1.10.0-rc.3
     op-batcher:


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Enables the deployment of flashblocks-websocket-proxy service on eris-0

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
