### PR TITLE
Updates README with ad-hoc devnet model that's been adopted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Platforms team maintains two parallel devnets. Protocol upgrades promote fro
 - **Alphanet:** Contains production-bound protocol upgrades that will be scheduled in *some* upcoming hardfork. All updates are active at genesis. The purpose of this devnet is to deploy protocol upgrades earlier, and to decouple deployment from hardfork scheduling. Protocol upgrades **must** be deployed on Alphanet before being deployed on the Betanet.
 - **Betanet:** Contains production-bound protocol upgrades that will be scheduled in the *next* hardfork. Upgrades are activated after genesis using hardfork timestamps. The purpose of this hardfork is to validate the upgrade process, and solidify the scope of a hardfork before activating it on our production testnet. Protocol upgrades **must** be deployed on the betanet before being deployed on testnet.
 
-Alphanets are deployed every 3 weeks. The Alphanet will be redeployed even if there are no changes to prevent a devnet from becoming someone’s production network. The Betanet is deployed on an ad-hoc basis when we’re ready to cut the next hardfork, and will persist until the next Betanet is cut.
+Alphanets and Betanets are deployed on an ad-hoc basis as features become ready for the next hardfork.
 
 # Operations
 
@@ -15,8 +15,9 @@ Devnet coordination will be centered around this repostory.
 
 ### Scoping Issue
 
-Platforms will propose the devnet scope in a github issue, tag the protocol team for feedback and finalize the scope.
-Aspirationally, it should include a list of features, each containing:
+Devnet requests are raised to Platforms as features are developed. The recurring upgrades standups act as a regular forum for cross-team alignment around devnet needs.
+
+Devnet scope is captured in GitHub issues in this repo. Aspirationally, it should include a list of features, each containing:
 
 - A short description of the feature
 - Monitoring / alerting requirements, new metrics to be aware of
@@ -55,15 +56,14 @@ After the devnet is deployed we publish a deployment artifacts file, including:
 
 ## Timeline
 
-The Alphanet will be deployed **on wednesday every 3 weeks**. The Betanet is deployed on an as-needed basis, but following the schedule described below.
 
-The Alphanet lasts for 3 weeks, at which point it is replaced by the next one. We are deliberately limiting the amount of time devnets stick around so folks do not rely on them long-term.
+Alphanets and Betanets are deployed on an as-needed basis following a roughly 3-4 week lifecycle as outlined in the table below.
 
-Here's the table converted to markdown format:
+We are deliberately limiting the amount of time devnets stick around so folks do not rely on them long-term.
 
 | Time | Activities |
 |------|------------|
-| D-5 | - Platforms proposes devnet scope + config |
+| D-5 | - Platforms and protocol define devnet scope + config |
 | D-2 | - Pull request for devnet manifest is created, reviewed, merged. |
 | D-1 | - Deploy the devnet<br>- Run basic network smoke tests |
 | D-0 | - Create the devnet artifact file PR. Review and Merge.<br>- Devnet is made public |

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ Alphanets and Betanets are deployed on an ad-hoc basis as features become ready 
 
 # Operations
 
-Devnet coordination will be centered around this repostory.
+Devnet coordination will be centered around this repostory. Devnet requests are raised to Platforms as features are developed by creating an issue in this repo using [this link](https://github.com/ethereum-optimism/devnets/issues/new?template=devnet-request.yml).
+
+The recurring upgrades standups also act as a regular forum for cross-team alignment around devnet needs.
 
 ## Issues
 
 ### Scoping Issue
 
-Devnet requests are raised to Platforms as features are developed. The recurring upgrades standups act as a regular forum for cross-team alignment around devnet needs.
-
-Devnet scope is captured in GitHub issues in this repo. Aspirationally, it should include a list of features, each containing:
+Devnet scope is captured in GitHub issues in this repo and should include a list of features, each containing:
 
 - A short description of the feature
 - Monitoring / alerting requirements, new metrics to be aware of


### PR DESCRIPTION
As recently discussed and announced, we're moving away from the devnet release train towards a more ad-hoc devnet cadence, while maintaining the alphanet and betanet definitions and promotion path.