### PR TITLE
Update devnet issue template with callouts for changing network topology

### DIFF
--- a/.github/ISSUE_TEMPLATE/devnet-request.yml
+++ b/.github/ISSUE_TEMPLATE/devnet-request.yml
@@ -39,6 +39,7 @@ body:
         - Links to design documents
         - Links to specs
         - Links to FMAs
+        - Especially call out any changes to network topology, as these involve changes to Platforms tooling
     validations:
       required: true
   - type: textarea
@@ -48,4 +49,5 @@ body:
       description: What configurations are needed for this devnet?
       placeholder: |
         - specific component versions or configurations
+        - any differences from a typical network topology (e.g., introduces new components, change in # or types of components)
         - anything else we need to know to deploy this devnet?


### PR DESCRIPTION
Updating the devnets issue template to match the recent changes made to the README emphasizing the bigger lift network topology changes typically represent for Platforms (see the [Operations section](https://github.com/ethereum-optimism/devnets?tab=readme-ov-file#operations)).