### PR TITLE
chore: bump geth versions to include geth cherry-pick-triedb/pathdb: sync ancient store before journal (#32557) (#718)

### DIFF
--- a/betanets/jovian-beta/manifest.yaml
+++ b/betanets/jovian-beta/manifest.yaml
@@ -37,7 +37,7 @@ l2:
     op-conductor:
       version: op-conductor/v0.9.0
     op-geth:
-      version: op-geth/v1.101603.4-rc.1
+      version: op-geth/v1.101603.4-rc.2
     op-node:
       version: op-node/v1.16.1-rc.1
     op-program:


### PR DESCRIPTION
…

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
