### PR TITLE
feat: clone templates from devnets-templates repo with cookie cutter …

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,107 @@
+# Devnet management for devnets repository
+#
+# Creates devnets using cookiecutter templates from devnet-templates repo
+# Templates are fetched via SSH from GitHub
+
+TEMPLATES_REPO := "git@github.com:ethereum-optimism/devnet-templates.git"
+TEMPLATES_BRANCH := "main"
+
+# Default: show help
+default:
+    @just --list
+    @echo ""
+    @echo "Create devnets using cookiecutter templates from devnet-templates"
+    @echo ""
+    @echo "Usage: just create-devnet <alphanets|betanets> <name> <preset>"
+    @echo ""
+    @echo "Run 'just list-presets' to see available presets"
+    @echo ""
+    @echo "Examples:"
+    @echo "  just create-devnet alphanets my-test alphanet"
+    @echo "  just create-devnet betanets rehearsal-3 betanet"
+    @echo "  just create-devnet alphanets reth-test reth"
+
+# List available presets from the templates repo
+list-presets:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    
+    echo "Fetching presets from {{TEMPLATES_REPO}}..."
+    echo ""
+    
+    TEMP_DIR=$(mktemp -d)
+    trap "rm -rf $TEMP_DIR" EXIT
+    
+    git clone --depth 1 --branch {{TEMPLATES_BRANCH}} {{TEMPLATES_REPO}} "$TEMP_DIR" 2>/dev/null
+    
+    # Find the inventories directory
+    INVENTORIES_DIR=$(find "$TEMP_DIR/cookiecutter-devnet" -type d -name "_inventories" 2>/dev/null | head -1)
+    
+    if [ -z "$INVENTORIES_DIR" ] || [ ! -d "$INVENTORIES_DIR" ]; then
+        echo "Error: Could not find inventories directory"
+        exit 1
+    fi
+    
+    echo "Available presets:"
+    for file in "$INVENTORIES_DIR"/*.yaml; do
+        if [ -f "$file" ]; then
+            preset=$(basename "$file" .yaml)
+            printf "  %s\n" "$preset"
+        fi
+    done
+    echo ""
+    echo "Usage: just create-devnet <alphanets|betanets> <name> <preset>"
+
+# Create a new devnet with the given name using a specific preset
+create-devnet net_type name preset:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    
+    # Check if cookiecutter is installed
+    if ! command -v cookiecutter &> /dev/null; then
+        echo "Error: cookiecutter is not installed"
+        echo "Install it with: pip install cookiecutter"
+        exit 1
+    fi
+    
+    # Validate net_type
+    if [[ "{{net_type}}" != "alphanets" && "{{net_type}}" != "betanets" ]]; then
+        echo "Error: net_type must be 'alphanets' or 'betanets', got '{{net_type}}'"
+        exit 1
+    fi
+    
+    PRESET="{{preset}}"
+    TARGET_DIR="{{net_type}}/{{name}}"
+    
+    # Check if directory already exists
+    if [ -d "$TARGET_DIR" ]; then
+        echo "Error: Devnet '{{name}}' already exists at $TARGET_DIR"
+        exit 1
+    fi
+    
+    echo "Creating {{net_type}} devnet '{{name}}' with preset '$PRESET'..."
+    
+    # Use the unified cookiecutter-devnet template with preset selection
+    # Cookiecutter will validate the preset against cookiecutter.json choices
+    if ! cookiecutter "{{TEMPLATES_REPO}}" \
+        --checkout {{TEMPLATES_BRANCH}} \
+        --directory "cookiecutter-devnet" \
+        --no-input \
+        --output-dir "{{net_type}}" \
+        devnet_name="{{name}}" \
+        preset="$PRESET" \
+        description="$PRESET configuration for {{name}}" 2>&1; then
+        echo ""
+        echo "Error: Failed to create devnet. Preset '$PRESET' may not exist."
+        echo "Run 'just list-presets' to see available presets."
+        exit 1
+    fi
+    
+    echo ""
+    echo "✓ Successfully created devnet: {{name}}"
+    echo "  Location: $TARGET_DIR"
+    echo "  Preset: $PRESET"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Edit $TARGET_DIR/manifest.yaml to configure your devnet"
+    echo "  2. Edit $TARGET_DIR/inventory.yaml to configure nodes and services"

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
-
 mdbook = "v0.4.43"
 uv = "0.9.5"
+"pipx:cookiecutter" = "2.6.0"


### PR DESCRIPTION
…and just

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
* Allows for cloning reusable templates from devnets-templates repository with cookie cutter

**Tests**

```
╭─ ~/workspace/ethereum-optimism/devnets jelias2/defa…ookie-cutter *1 ?11                                                                                                           16:18:45
╰─❯ just
Available recipes:
    create-devnet net_type name preset # Create a new devnet with the given name using a specific preset
    default                            # Default: show help
    list-presets                       # List available presets from the templates repo

Create devnets using cookiecutter templates from devnet-templates

Usage: just create-devnet <alphanets|betanets> <name> <preset>

Run 'just list-presets' to see available presets

Examples:
  just create-devnet alphanets my-test alphanet
  just create-devnet betanets rehearsal-3 betanet
  just create-devnet alphanets reth-test reth

╭─ ~/workspace/ethereum-optimism/devnets jelias2/defa…ookie-cutter *1 ?11                                                                                                           16:19:52
╰─❯ just list-presets
Fetching presets from git@github.com:ethereum-optimism/devnet-templates.git...

Available presets:
  alphanet
  betanet
  reth

Usage: just create-devnet <alphanets|betanets> <name> <preset>

╭─ ~/workspace/ethereum-optimism/devnets jelias2/defa…ookie-cutter *1 ?11                                                                                                           16:19:57
╰─❯ just create-devnet alphanets jacob-test-4 reth
Creating alphanets devnet 'jacob-test-4' with preset 'reth'...
  ✓ Using reth inventory preset

✓ Successfully created devnet: jacob-test-4
  Location: alphanets/jacob-test-4
  Preset: reth

Next steps:
  1. Edit alphanets/jacob-test-4/manifest.yaml to configure your devnet
  2. Edit alphanets/jacob-test-4/inventory.yaml to configure nodes and services

╭─ ~/workspace/ethereum-optimism/devnets jelias2/defa…ookie-cutter *1 ?12                                                                                                           16:20:03
╰─❯ just create-devnet betanets jacob-test-5 betanet
Creating betanets devnet 'jacob-test-5' with preset 'betanet'...
  ✓ Using betanet inventory preset

✓ Successfully created devnet: jacob-test-5
  Location: betanets/jacob-test-5
  Preset: betanet

Next steps:
  1. Edit betanets/jacob-test-5/manifest.yaml to configure your devnet
  2. Edit betanets/jacob-test-5/inventory.yaml to configure nodes and services

╭─ ~/workspace/ethereum-optimism/devnets jelias2/defa…ookie-cutter *1 ?13                                                                                                           16:20:17
╰─❯ gs
On branch jelias2/default-inventories-cookie-cutter
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.netchef/
	alphanets/jacob-test-4/
	betanets/jacob-test-5/
```

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

