### PR TITLE
feat: flashblocks by default on the devnet templates

### DIFF
--- a/justfile
+++ b/justfile
@@ -90,7 +90,8 @@ create-devnet net_type name preset:
         --output-dir "{{net_type}}" \
         devnet_name="{{name}}" \
         preset="$PRESET" \
-        description="$PRESET configuration for {{name}}" 2>&1; then
+        description="$PRESET configuration for {{name}}" \
+        flashblock_enabled=true 2>&1; then
         echo ""
         echo "Error: Failed to create devnet. Preset '$PRESET' may not exist."
         echo "Run 'just list-presets' to see available presets."


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
* Add flashblocks by default when using devnet templates

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
