### PR TITLE
Pins CI netchef image

### DIFF
--- a/cloudbuild-merge-queue.yaml
+++ b/cloudbuild-merge-queue.yaml
@@ -22,7 +22,7 @@ steps:
     - name: 'ssh'
       path: /root/.ssh
 
-  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:main
+  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:1ad380431d546d6c93a89001794bda7353a610ac
     args: ["ci", "validate", "--devnets-dir", "."]
     env:
       - NETCHEF_GCP_PROJECT=oplabs-dev-infra

--- a/cloudbuild-push-main.yaml
+++ b/cloudbuild-push-main.yaml
@@ -22,13 +22,13 @@ steps:
     - name: 'ssh'
       path: /root/.ssh
 
-  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:main
+  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:1ad380431d546d6c93a89001794bda7353a610ac
     args: ["ci", "validate", "--devnets-dir", "."]
     env:
       - NETCHEF_GCP_PROJECT=oplabs-dev-infra
       - NETCHEF_REPO_URL=https://github.com/ethereum-optimism/devnets.git
 
-  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:main
+  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:1ad380431d546d6c93a89001794bda7353a610ac
     entrypoint: "ci-command-on-devnet-changes.sh"
     args: ["check-for-open-workflows"]
     env:
@@ -38,7 +38,7 @@ steps:
     secretEnv:
       - NETCHEF_TEMPORAL_API_KEY
 
-  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:main
+  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:1ad380431d546d6c93a89001794bda7353a610ac
     entrypoint: "ci-command-on-devnet-changes.sh"
     args: ["trigger-workflow"]
     env:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,12 +21,12 @@ steps:
     volumes:
     - name: 'ssh'
       path: /root/.ssh
-  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:main
+  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:1ad380431d546d6c93a89001794bda7353a610ac
     args: ["ci", "validate", "--devnets-dir", "."]
     env:
       - NETCHEF_GCP_PROJECT=oplabs-dev-infra
       - NETCHEF_REPO_URL=https://github.com/ethereum-optimism/devnets.git
-  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:main
+  - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:1ad380431d546d6c93a89001794bda7353a610ac
     entrypoint: "ci-command-on-devnet-changes.sh"
     args: ["store-pr-context", ".", "--base"]
     env:


### PR DESCRIPTION
CI currently broken due to this change [netchef: Support multiple versions of op-deployer [7 ½/N] (](https://github.com/ethereum-optimism/infrastructure-services/commit/a86d9d7cbb27e4a8395dd7fc6c35febf51b838ba)\

build log: https://console.cloud.google.com/logs/query?advancedFilter=resource.type%3D%22build%22%20AND%20resource.labels.build_id%3D%2283a28843-7979-44da-9e11-a812918ddb86%22%20AND%20resource.labels.build_trigger_id%3D%2206a00763-9e72-4b8d-ab67-15e12f279df0%22&project=oplabs-tools-infra