### PR TITLE
[netchef] CreateNetwork revshare-beta - status update

### DIFF
--- a/betanets/revshare-beta/manifest.yaml
+++ b/betanets/revshare-beta/manifest.yaml
@@ -1,7 +1,7 @@
 name: revshare-beta
 type: betanet
 scope: https://github.com/ethereum-optimism/devnets/issues/192
-status: pending
+status: online
 description: |
     * Flashblocks
     * Low Finality Delay


### PR DESCRIPTION
Network status updated for revshare-beta to online.

This PR was created automatically by the Netchef temporal workflow CreateNetwork-netchef-deploy-devnet-revshare-alpha