### PR TITLE
[netchef] CreateNetwork revshare-alpha - status update

### DIFF
--- a/alphanets/revshare-alpha/manifest.yaml
+++ b/alphanets/revshare-alpha/manifest.yaml
@@ -1,7 +1,7 @@
 name: revshare-alpha
 type: alphanet
 scope: https://github.com/ethereum-optimism/devnets/issues/192
-status: pending
+status: online
 description: |
     * Low Finality Delay
     * RevShare


### PR DESCRIPTION
Network status updated for revshare-alpha to online.

This PR was created automatically by the Netchef temporal workflow CreateNetwork-netchef-deploy-devnet-revshare-alpha