### PR TITLE
[netchef] CreateNetwork interop-jnt-v0 - status update
#netchef-skip-workflows

### DIFF
--- a/alphanets/interop-jnt-v0/manifest.yaml
+++ b/alphanets/interop-jnt-v0/manifest.yaml
@@ -1,7 +1,7 @@
 name: interop-jnt-v0
 type: alphanet
 scope: https://github.com/ethereum-optimism/devnets/issues/276
-status: pending
+status: online
 description: |
     * interop joint network v2 (gs/temp-hacky-devnet-interop branch)
     * interop activated 60s after genesis


### PR DESCRIPTION
Network status updated for interop-jnt-v0 to online.

This PR was created automatically by the Netchef temporal workflow CreateNetwork-netchef-create-network-interop-jnt-v0