### PR TITLE
chore: remove op-acceptor from interop-jnt-v0

### DIFF
--- a/alphanets/interop-jnt-v0/inventory.yaml
+++ b/alphanets/interop-jnt-v0/inventory.yaml
@@ -370,11 +370,6 @@ chains:
             - "rpc-0"
 
 services:
-  - kind: "test-runner"
-    name: "op-acceptor"
-    spec:
-      kind: "op-acceptor"
-
   - kind: "supernode"
     name: "op-supernode-0"
     spec:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
