### PR TITLE
[netchef] CreateNetwork interop-jnt-v1 - status update
#netchef-skip-workflows

### DIFF
--- a/alphanets/interop-jnt-v1/manifest.yaml
+++ b/alphanets/interop-jnt-v1/manifest.yaml
@@ -1,6 +1,6 @@
 name: interop-jnt-v1
 type: alphanet
-status: pending
+status: online
 description: |
     * interop-jnt-v1 network for joint sequencing
     * interop activated 60s after genesis


### PR DESCRIPTION
Network status updated for interop-jnt-v1 to online.

This PR was created automatically by the Netchef temporal workflow CreateNetwork-netchef-create-network-interop-jnt-v1