### PR TITLE
Update CI to use new dev project/namespace

### DIFF
--- a/cloudbuild-push-main.yaml
+++ b/cloudbuild-push-main.yaml
@@ -25,7 +25,7 @@ steps:
   - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:main
     args: ["ci", "validate", "--devnets-dir", "."]
     env:
-      - NETCHEF_GCP_PROJECT_DEV=oplabs-tools-infra
+      - NETCHEF_GCP_PROJECT_DEV=oplabs-dev-ent-infra-us
       - NETCHEF_GCP_PROJECT_PROD=oplabs-prod-ent-infra-us
       - NETCHEF_GCP_PROJECT_STG=oplabs-stg-ent-infra-us
       - NETCHEF_REPO_URL=https://github.com/ethereum-optimism/devnets.git
@@ -37,7 +37,7 @@ steps:
       - NETCHEF_TEMPORAL_HOST=us-central1.gcp.api.temporal.io:7233
       - NETCHEF_TEMPORAL_TASK_QUEUE=netchef-main-workflows
       - NETCHEF_TEMPORAL_NAMESPACE_PROD=oplabs-prod-ent-infra-netchef.nqbqu
-      - NETCHEF_TEMPORAL_NAMESPACE_DEV=dev-netchef.nqbqu
+      - NETCHEF_TEMPORAL_NAMESPACE_DEV=oplabs-dev-ent-infra-netchef.nqbqu
       - NETCHEF_TEMPORAL_NAMESPACE_STG=oplabs-stg-ent-infra-netchef.nqbqu
     secretEnv:
       - NETCHEF_TEMPORAL_API_KEY
@@ -49,12 +49,12 @@ steps:
     entrypoint: "ci-command-on-devnet-changes.sh"
     args: ["trigger-workflow"]
     env:
-      - NETCHEF_GCP_PROJECT_DEV=oplabs-tools-infra
+      - NETCHEF_GCP_PROJECT_DEV=oplabs-dev-ent-infra-us
       - NETCHEF_GCP_PROJECT_PROD=oplabs-prod-ent-infra-us
       - NETCHEF_GCP_PROJECT_STG=oplabs-stg-ent-infra-us
       - NETCHEF_REPO_URL=https://github.com/ethereum-optimism/devnets.git
       - NETCHEF_TEMPORAL_NAMESPACE_PROD=oplabs-prod-ent-infra-netchef.nqbqu
-      - NETCHEF_TEMPORAL_NAMESPACE_DEV=dev-netchef.nqbqu
+      - NETCHEF_TEMPORAL_NAMESPACE_DEV=oplabs-dev-ent-infra-netchef.nqbqu
       - NETCHEF_TEMPORAL_NAMESPACE_STG=oplabs-stg-ent-infra-netchef.nqbqu
       - NETCHEF_TEMPORAL_HOST=us-central1.gcp.api.temporal.io:7233
       - NETCHEF_TEMPORAL_TASK_QUEUE=netchef-main-workflows

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   - name: us-docker.pkg.dev/oplabs-tools-artifacts/internal-images/netchef:main
     args: ["ci", "validate", "--devnets-dir", "."]
     env:
-      - NETCHEF_GCP_PROJECT_DEV=oplabs-tools-infra
+      - NETCHEF_GCP_PROJECT_DEV=oplabs-dev-ent-infra-us
       - NETCHEF_GCP_PROJECT_PROD=oplabs-prod-ent-infra-us
       - NETCHEF_GCP_PROJECT_STG=oplabs-stg-ent-infra-us
       - NETCHEF_REPO_URL=https://github.com/ethereum-optimism/devnets.git
@@ -32,7 +32,7 @@ steps:
     entrypoint: "ci-command-on-devnet-changes.sh"
     args: ["store-pr-context", ".", "--base"]
     env:
-      - NETCHEF_GCP_PROJECT_DEV=oplabs-tools-infra
+      - NETCHEF_GCP_PROJECT_DEV=oplabs-dev-ent-infra-us
       - NETCHEF_GCP_PROJECT_PROD=oplabs-prod-ent-infra-us
       - NETCHEF_GCP_PROJECT_STG=oplabs-stg-ent-infra-us
       - NETCHEF_PR_NUMBER=${_PR_NUMBER}


### PR DESCRIPTION
## Description
The following PR updates our CI jobs to point to the new dev project & namespace. This will initiate the migration from tools -> dev.