### PR TITLE
chore: pin op-supernode-3 to v0.2.1 in interop-jnt-v1

### DIFF
--- a/alphanets/interop-jnt-v1/inventory.yaml
+++ b/alphanets/interop-jnt-v1/inventory.yaml
@@ -471,6 +471,8 @@ services:
       spec:
           kind: "op-supernode"
           values:
+            image:
+              tag: "v0.2.1"
             env:
               OP_SUPERNODE_VN_420120070_SYNCMODE: "consensus-layer"
               OP_SUPERNODE_VN_420120071_SYNCMODE: "consensus-layer"


### PR DESCRIPTION
updates sn3 to 0.2.1