### PR TITLE
chore: bump supernode versions to v0.2.1

### DIFF
--- a/alphanets/interop-jnt-v1/inventory.yaml
+++ b/alphanets/interop-jnt-v1/inventory.yaml
@@ -485,7 +485,10 @@ services:
       spec:
           kind: "op-supernode"
           values:
+              image:
+                  tag: "v0.2.1"
               env:
+                  OP_SUPERNODE_LOG_LEVEL: "debug"
                   OP_SUPERNODE_VN_420120070_SYNCMODE: "consensus-layer"
                   OP_SUPERNODE_VN_420120071_SYNCMODE: "consensus-layer"
                   OP_SUPERNODE_VN_ALL_SYNCMODE: "consensus-layer"
@@ -498,7 +501,10 @@ services:
       spec:
           kind: "op-supernode"
           values:
+              image:
+                  tag: "v0.2.1"
               env:
+                  OP_SUPERNODE_LOG_LEVEL: "debug"
                   OP_SUPERNODE_VN_420120070_SYNCMODE: "consensus-layer"
                   OP_SUPERNODE_VN_420120071_SYNCMODE: "consensus-layer"
                   OP_SUPERNODE_VN_ALL_SYNCMODE: "consensus-layer"


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
