### PR TITLE
circleci: Tier A Gen2 swap + interop-jnt-v2 status online

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   docs-build:
     docker:
       - image: cimg/rust:1.84.0
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -27,7 +27,7 @@ jobs:
   docs-deploy:
     docker:
       - image: cimg/rust:1.84.0
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/dev/interop-jnt-v2/manifest.yaml
+++ b/dev/interop-jnt-v2/manifest.yaml
@@ -1,6 +1,6 @@
 name: interop-jnt-v2
 type: betanet
-status: pending
+status: online
 description: |
     * interop network testing SuperDisputeGame with op-deployer v0.7.0-alpha.2
     * interop activated 60s after genesis


### PR DESCRIPTION
## Summary

Two changes:

1. **CircleCI Gen2 swap** (W4): 2 docker jobs in `.circleci/config.yml`, same-size mechanical token replacement (`medium` → `medium.gen2`). Part of W4 of the CircleCI cost-reduction initiative — see ethereum-optimism/core-team#2564.
2. **interop-jnt-v2 status → online**: flips `dev/interop-jnt-v2/manifest.yaml` from `status: pending` to `status: online`. Network is up and ready; this unblocks netchef GCB validation on the PR.

## Change

### `.circleci/config.yml` (Gen2 migration)

2 docker job defs:

| Current → New | Jobs |
|---|---|
| `medium` → `medium.gen2` | `docs-build`, `docs-deploy` |

### `dev/interop-jnt-v2/manifest.yaml`

Single-line change: `status: pending` → `status: online`. Matches the convention used by active devnets (e.g. `eris`).

## Rationale

**Gen2 swap**: Same-size Gen2 swaps are equivalent in vCPU/RAM to Gen1 counterparts at the same advertised class. They position us ahead of Gen1 deprecation and typically run slightly faster on identical workloads. No xlsx telemetry was available for this repo — primarily Gen1-deprecation prep.

**Status flip**: `interop-jnt-v2` was created with `status: pending` in #331. The network is now up; flipping to `online` reflects current state and unblocks the netchef GCB validation that was failing on this PR.

## Validation

- **Gen2 swap**: Mechanical token replacement only. File byte-size delta on `.circleci/config.yml` matches `5 bytes × 2 edits = +10` exactly. No structural changes. The `ci/circleci: docs-build` check is already green on this branch.
- **Status flip**: Single field-value change on `dev/interop-jnt-v2/manifest.yaml` (+1/-1 line). No structural changes.

## Refs

- ethereum-optimism/core-team#2564 (W4 CircleCI Gen2 migration)
- ethereum-optimism/optimism#20917 (W4 optimism Tier A PR — establishes the same-size Gen2 pattern, all 99 checks green)
- ethereum-optimism/optimism#20899 (pilot PR, green)
- #331 (interop-jnt-v2 creation)