### PR TITLE
chore: pin jnt-v2 supernodes and set per-chain CL sync

### DIFF
--- a/dev/interop-jnt-v2/inventory.yaml
+++ b/dev/interop-jnt-v2/inventory.yaml
@@ -659,6 +659,8 @@ services:
       spec:
           kind: "op-supernode"
           values:
+              image:
+                  tag: "develop@sha256:1d38746eb0aaf83f47acaa3f45352bb2dac402ab9b8de2df0d6d57f82c0775c8"
               env:
                   OP_SUPERNODE_VN_ALL_P2P_LISTEN_TCP_PORT: "0"
                   OP_SUPERNODE_VN_ALL_P2P_LISTEN_UDP_PORT: "0"
@@ -666,6 +668,8 @@ services:
                   OP_SUPERNODE_VN_ALL_P2P_ADVERTISE_UDP: "0"
                   OP_SUPERNODE_INTEROP_LOG_BACKFILL_DEPTH: "1h"
                   OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP: "1778603980"
+                  OP_SUPERNODE_VN_420120102_SYNCMODE: "consensus-layer"
+                  OP_SUPERNODE_VN_420120103_SYNCMODE: "consensus-layer"
                   OP_SUPERNODE_VN_ALL_SYNCMODE: "consensus-layer"
       deps:
           nodes:
@@ -676,12 +680,16 @@ services:
       spec:
           kind: "op-supernode"
           values:
+              image:
+                  tag: "develop@sha256:1d38746eb0aaf83f47acaa3f45352bb2dac402ab9b8de2df0d6d57f82c0775c8"
               env:
                   OP_SUPERNODE_VN_ALL_P2P_LISTEN_TCP_PORT: "0"
                   OP_SUPERNODE_VN_ALL_P2P_LISTEN_UDP_PORT: "0"
                   OP_SUPERNODE_VN_ALL_P2P_ADVERTISE_TCP: "0"
                   OP_SUPERNODE_VN_ALL_P2P_ADVERTISE_UDP: "0"
                   OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP: "1778603980"
+                  OP_SUPERNODE_VN_420120102_SYNCMODE: "consensus-layer"
+                  OP_SUPERNODE_VN_420120103_SYNCMODE: "consensus-layer"
                   OP_SUPERNODE_VN_ALL_SYNCMODE: "execution-layer"
       deps:
           nodes:
@@ -692,6 +700,8 @@ services:
       spec:
           kind: "op-supernode"
           values:
+              image:
+                  tag: "develop@sha256:1d38746eb0aaf83f47acaa3f45352bb2dac402ab9b8de2df0d6d57f82c0775c8"
               env:
                   OP_SUPERNODE_INTEROP_LOG_BACKFILL_DEPTH: "10m"
                   OP_SUPERNODE_VN_ALL_P2P_LISTEN_TCP_PORT: "0"
@@ -699,6 +709,8 @@ services:
                   OP_SUPERNODE_VN_ALL_P2P_ADVERTISE_TCP: "0"
                   OP_SUPERNODE_VN_ALL_P2P_ADVERTISE_UDP: "0"
                   OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP: "1778603980"
+                  OP_SUPERNODE_VN_420120102_SYNCMODE: "consensus-layer"
+                  OP_SUPERNODE_VN_420120103_SYNCMODE: "consensus-layer"
                   OP_SUPERNODE_VN_ALL_SYNCMODE: "execution-layer"
       deps:
           nodes:
@@ -709,12 +721,16 @@ services:
       spec:
           kind: "op-supernode"
           values:
+              image:
+                  tag: "develop@sha256:1d38746eb0aaf83f47acaa3f45352bb2dac402ab9b8de2df0d6d57f82c0775c8"
               env:
                   OP_SUPERNODE_VN_ALL_P2P_LISTEN_TCP_PORT: "0"
                   OP_SUPERNODE_VN_ALL_P2P_LISTEN_UDP_PORT: "0"
                   OP_SUPERNODE_VN_ALL_P2P_ADVERTISE_TCP: "0"
                   OP_SUPERNODE_VN_ALL_P2P_ADVERTISE_UDP: "0"
                   OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP: "1778603980"
+                  OP_SUPERNODE_VN_420120102_SYNCMODE: "consensus-layer"
+                  OP_SUPERNODE_VN_420120103_SYNCMODE: "consensus-layer"
                   OP_SUPERNODE_VN_ALL_SYNCMODE: "execution-layer"
       deps:
           nodes:


### PR DESCRIPTION
## Summary

- Pin all four `dev/interop-jnt-v2` supernodes to the live digest-backed supernode image: `develop@sha256:1d38746eb0aaf83f47acaa3f45352bb2dac402ab9b8de2df0d6d57f82c0775c8`.
- Add explicit per-chain consensus-layer sync for both JNT v2 chain IDs: `420120102` and `420120103`.
- Leave the existing `OP_SUPERNODE_VN_ALL_SYNCMODE` fallback behavior unchanged.

## Context

While debugging the JNT v2 supernodes, the live recovery path used a custom supernode image plus explicit per-chain CL sync. This PR persists those intended node changes without carrying over temporary operational drift such as activation timestamp or backfill-depth edits.

Note: `alphanets/interop-jnt-v1` already has equivalent per-chain CL sync settings and is currently marked offline. The active network we changed is represented by `dev/interop-jnt-v2`.

## Validation

- Parsed `dev/interop-jnt-v2/inventory.yaml` and `dev/interop-jnt-v2/manifest.yaml` with Ruby YAML successfully.
- Compared against live supernode config: all four live supernodes use the same per-chain CL sync settings and the same supernode image digest.