### PR TITLE
chore: update interop-jnt-v2 supernode images

### DIFF
--- a/dev/interop-jnt-v2/manifest.yaml
+++ b/dev/interop-jnt-v2/manifest.yaml
@@ -70,9 +70,9 @@ l2:
         op-rbuilder:
             version: op-rbuilder/v0.3.2-rc5
         op-reth:
-            version: op-reth/v2.2.3
+            version: op-reth/v2.2.5-rc.1
         op-supernode:
-            version: op-supernode/v0.3.1-rc.1
+            version: op-supernode/v0.3.1-rc.2
         peer-mgmt-service:
             version: peer-mgmt-service/v0.0.3
         proxyd:


### PR DESCRIPTION
Updates the interop-jnt-v2 component pins to the latest tagged RCs we have been running/debugging against:

- op-reth: `op-reth/v2.2.5-rc.1`
- op-supernode: `op-supernode/v0.3.1-rc.2`

Context:
- The live incident recovery was blocked by stale/missing chain2 reth state on SN0, while SN1 had a healthier chain2 DB.
- We copied SN1 chain2 reth state into SN0 chain2 reth, restarted the relevant writers, and SN0 chain2 stopped failing on the previously missing payload path.
- SN1 recovered after the supernode restart: both chains now report nonzero safe/finalized, chain1 latest is live, and chain2 is at the expected ~12h lag.
- SN0 is still catching up, but it is now steadily advancing safe/finalized on both chains instead of failing on missing chain2 payloads.

Validation so far:
- Rebased this branch onto latest `origin/main`.
- Verified the PR diff is limited to `dev/interop-jnt-v2/manifest.yaml`.
- Verified current diff only changes the `op-reth` and `op-supernode` image pins.
- Live watch after the state copy shows SN0 safe/finalized advancing on both chains and SN1 recovered to nonzero safe/finalized.

Notes:
- This PR intentionally does not include generated k8s output.
- Existing `dev/interop-jnt-v2/inventory.yaml` on `main` already contains the supernode sync-mode/archive-style settings we were relying on; this PR records the remaining image-pin change in the source of truth.
- Leaving as draft until SN0 finishes catching up to the expected live definition (chain1 current, chain2 healthy with the expected ~12h lag).