### PR TITLE
chore: offline u19 networks

### DIFF
--- a/betanets/u19-beta/manifest.yaml
+++ b/betanets/u19-beta/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-beta
 type: betanet
 scope: https://github.com/ethereum-optimism/devnets/issues/316
-status: online
+status: offline
 description: |
     * U19 Betanet
       * Osaka on L2

--- a/dev/u19-alpha-perm/manifest.yaml
+++ b/dev/u19-alpha-perm/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-alpha-perm
 type: alphanet
 scope: https://github.com/ethereum-optimism/devnets/issues/343
-status: pending
+status: offline
 description: |
     * U19 Alphanet (Permissioned baseline)
       * Karst activated at genesis (Osaka EIPs, L2CM, CANNON_KONA)

--- a/dev/u19-alpha/manifest.yaml
+++ b/dev/u19-alpha/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-alpha
 type: alphanet
 scope: https://github.com/ethereum-optimism/devnets/issues/339
-status: online
+status: offline
 description: |
     * U19 Alphanet
       * Osaka on L2


### PR DESCRIPTION
## Summary
- Sets `u19-alpha` (alphanets/dev) to `offline`
- Sets `u19-alpha-perm` (alphanets/dev) to `offline`
- Sets `u19-beta` (betanets) to `offline` — covers both `u19-beta-0` and `u19-beta-1`

## Test plan
- [ ] CI netchef validate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)