### PR TITLE
chore: bring u19 networks back online

### DIFF
--- a/betanets/u19-beta/manifest.yaml
+++ b/betanets/u19-beta/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-beta
 type: betanet
 scope: https://github.com/ethereum-optimism/devnets/issues/316
-status: pending
+status: online
 description: |
     * U19 Betanet
       * Osaka on L2

--- a/betanets/u19-beta/manifest.yaml
+++ b/betanets/u19-beta/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-beta
 type: betanet
 scope: https://github.com/ethereum-optimism/devnets/issues/316
-status: offline
+status: pending
 description: |
     * U19 Betanet
       * Osaka on L2

--- a/dev/u19-alpha-perm/manifest.yaml
+++ b/dev/u19-alpha-perm/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-alpha-perm
 type: alphanet
 scope: https://github.com/ethereum-optimism/devnets/issues/343
-status: offline
+status: pending
 description: |
     * U19 Alphanet (Permissioned baseline)
       * Karst activated at genesis (Osaka EIPs, L2CM, CANNON_KONA)

--- a/dev/u19-alpha-perm/manifest.yaml
+++ b/dev/u19-alpha-perm/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-alpha-perm
 type: alphanet
 scope: https://github.com/ethereum-optimism/devnets/issues/343
-status: pending
+status: offline
 description: |
     * U19 Alphanet (Permissioned baseline)
       * Karst activated at genesis (Osaka EIPs, L2CM, CANNON_KONA)

--- a/dev/u19-alpha/manifest.yaml
+++ b/dev/u19-alpha/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-alpha
 type: alphanet
 scope: https://github.com/ethereum-optimism/devnets/issues/339
-status: pending
+status: online
 description: |
     * U19 Alphanet
       * Osaka on L2

--- a/dev/u19-alpha/manifest.yaml
+++ b/dev/u19-alpha/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-alpha
 type: alphanet
 scope: https://github.com/ethereum-optimism/devnets/issues/339
-status: offline
+status: pending
 description: |
     * U19 Alphanet
       * Osaka on L2


### PR DESCRIPTION
## Summary
- Sets `u19-alpha`, `u19-alpha-perm`, and `u19-beta` (u19-beta-0, u19-beta-1) from `offline` → `pending` to trigger redeployment

Reverting the teardown from #346.

## Test plan
- [ ] CI netchef validate passes
- [ ] Approve and merge generated k8s PR after automation kicks off

🤖 Generated with [Claude Code](https://claude.com/claude-code)