### PR TITLE
feat(karst-u19-beta): manifest + inventory

### DIFF
--- a/dev/karst-u19-beta/inventory.yaml
+++ b/dev/karst-u19-beta/inventory.yaml
@@ -1,0 +1,458 @@
+chains:
+  # Chain 0 - Permissioned
+  - values:
+      op-node:
+        safeHeadDb:
+          persistentVolume:
+            size: 1Gi
+      op-reth:
+        persistentVolume:
+          size: 64Gi
+      op-rbuilder:
+        persistentVolume:
+          size: 64Gi
+    nodes:
+      - kind: "node"
+        name: "seq-0"
+        spec:
+          kind: "sequencer"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "op-node"
+          builder:
+            kind: "op-rbuilder"
+          flashblocks:
+            builder:
+              kind: "op-rbuilder"
+            rollup-boost:
+              kind: "rollup-boost"
+
+      - kind: "node"
+        name: "seq-1"
+        spec:
+          kind: "sequencer"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "op-node"
+          builder:
+            kind: "op-rbuilder"
+          flashblocks:
+            builder:
+              kind: "op-rbuilder"
+            rollup-boost:
+              kind: "rollup-boost"
+
+      - kind: "node"
+        name: "seq-2"
+        spec:
+          kind: "sequencer"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "op-node"
+          builder:
+            kind: "op-rbuilder"
+          flashblocks:
+            builder:
+              kind: "op-rbuilder"
+            rollup-boost:
+              kind: "rollup-boost"
+
+      - kind: "node"
+        name: "rpc-0"
+        spec:
+          kind: "rpc"
+          el:
+            kind: "op-geth"
+            spec:
+              kind: "archive"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "rpc-1"
+        spec:
+          kind: "rpc"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "archive"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "rpc-2"
+        spec:
+          kind: "rpc"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "archive"
+          cl:
+            kind: "kona-node"
+
+      - kind: "node"
+        name: "sync-0"
+        spec:
+          kind: "snapsync"
+          el:
+            kind: "op-geth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "sync-1"
+        spec:
+          kind: "snapsync"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "sync-2"
+        spec:
+          kind: "snapsync"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "kona-node"
+
+    services:
+      - kind: "proposer"
+        name: "op-proposer"
+        spec:
+          kind: "op-proposer"
+        deps:
+          nodes:
+            - "rpc-0"
+
+      - kind: "batcher"
+        name: "op-batcher"
+        spec:
+          kind: "op-batcher"
+        deps:
+          nodes:
+            - "seq-0"
+            - "seq-1"
+            - "seq-2"
+      - kind: "balance-mon"
+        name: "balance-mon"
+        spec:
+          kind: "balance-mon"
+
+      - kind: "challenger"
+        name: "op-challenger"
+        spec:
+          kind: "op-challenger"
+        deps:
+          nodes:
+            - "rpc-0"
+
+      - kind: "public-rpc"
+        name: "proxyd-public"
+        spec:
+          kind: "proxyd"
+        deps:
+          nodes:
+            - "rpc-0"
+            - "rpc-1"
+            - "rpc-2"
+
+      - kind: "peer-mgmt-service"
+        name: "peer-mgmt-service"
+        spec:
+          kind: "peer-mgmt-service"
+        deps:
+          nodes:
+            - "seq-0"
+            - "seq-1"
+            - "seq-2"
+            - "rpc-0"
+            - "rpc-1"
+            - "rpc-2"
+            - "sync-0"
+            - "sync-1"
+            - "sync-2"
+
+      - kind: "op-conductor-mon"
+        name: "op-conductor-mon"
+        spec:
+          kind: "op-conductor-mon"
+        deps:
+          nodes:
+            - "seq-0"
+            - "seq-1"
+            - "seq-2"
+
+      - kind: "op-conductor-ops"
+        name: "op-conductor-ops"
+        spec:
+          kind: "op-conductor-ops"
+        deps:
+          nodes:
+            - "seq-0"
+            - "seq-1"
+            - "seq-2"
+
+      - kind: "op-dispute-mon"
+        name: "op-dispute-mon"
+        spec:
+          kind: "op-dispute-mon"
+        deps:
+          nodes:
+            - "rpc-0"
+
+      - kind: "faucet"
+        name: "op-faucet"
+        spec:
+          kind: "op-faucet"
+        deps:
+          nodes:
+            - "rpc-0"
+      - kind: "flashblocks-websocket-proxy"
+        name: "fb-ws-proxy"
+        spec:
+          kind: "flashblocks-websocket-proxy"
+        deps:
+          nodes:
+            - "seq-0"
+            - "seq-1"
+            - "seq-2"
+
+  # Chain 1 - Permissionless
+  - values:
+      op-node:
+        safeHeadDb:
+          persistentVolume:
+            size: 1Gi
+      op-reth:
+        persistentVolume:
+          size: 64Gi
+      op-rbuilder:
+        persistentVolume:
+          size: 64Gi
+    nodes:
+      - kind: "node"
+        name: "seq-0"
+        spec:
+          kind: "sequencer"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "seq-1"
+        spec:
+          kind: "sequencer"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "seq-2"
+        spec:
+          kind: "sequencer"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "rpc-0"
+        spec:
+          kind: "rpc"
+          el:
+            kind: "op-geth"
+            spec:
+              kind: "archive"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "rpc-1"
+        spec:
+          kind: "rpc"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "archive"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "rpc-2"
+        spec:
+          kind: "rpc"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "archive"
+          cl:
+            kind: "kona-node"
+
+      - kind: "node"
+        name: "sync-0"
+        spec:
+          kind: "snapsync"
+          el:
+            kind: "op-geth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "sync-1"
+        spec:
+          kind: "snapsync"
+          el:
+            kind: "op-reth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "op-node"
+
+      - kind: "node"
+        name: "sync-2"
+        spec:
+          kind: "snapsync"
+          el:
+            kind: "op-geth"
+            spec:
+              kind: "full"
+          cl:
+            kind: "kona-node"
+
+    services:
+      - kind: "proposer"
+        name: "op-proposer"
+        spec:
+          kind: "op-proposer"
+        deps:
+          nodes:
+            - "rpc-0"
+
+      - kind: "batcher"
+        name: "op-batcher"
+        spec:
+          kind: "op-batcher"
+        deps:
+          nodes:
+            - "seq-0"
+            - "seq-1"
+            - "seq-2"
+      - kind: "balance-mon"
+        name: "balance-mon"
+        spec:
+          kind: "balance-mon"
+
+      - kind: "challenger"
+        name: "op-challenger"
+        spec:
+          kind: "op-challenger"
+        deps:
+          nodes:
+            - "rpc-0"
+
+      - kind: "public-rpc"
+        name: "proxyd-public"
+        spec:
+          kind: "proxyd"
+        deps:
+          nodes:
+            - "rpc-0"
+            - "rpc-1"
+            - "rpc-2"
+
+      - kind: "peer-mgmt-service"
+        name: "peer-mgmt-service"
+        spec:
+          kind: "peer-mgmt-service"
+        deps:
+          nodes:
+            - "seq-0"
+            - "seq-1"
+            - "seq-2"
+            - "rpc-0"
+            - "rpc-1"
+            - "rpc-2"
+            - "sync-0"
+            - "sync-1"
+            - "sync-2"
+
+      - kind: "op-conductor-mon"
+        name: "op-conductor-mon"
+        spec:
+          kind: "op-conductor-mon"
+        deps:
+          nodes:
+            - "seq-0"
+            - "seq-1"
+            - "seq-2"
+
+      - kind: "op-conductor-ops"
+        name: "op-conductor-ops"
+        spec:
+          kind: "op-conductor-ops"
+        deps:
+          nodes:
+            - "seq-0"
+            - "seq-1"
+            - "seq-2"
+
+      - kind: "op-dispute-mon"
+        name: "op-dispute-mon"
+        spec:
+          kind: "op-dispute-mon"
+        deps:
+          nodes:
+            - "rpc-0"
+
+      - kind: "op-challenger-runner"
+        name: "op-challenger-runner"
+        spec:
+          kind: "op-challenger-runner"
+        deps:
+          nodes:
+            - "rpc-0"
+
+      - kind: "faucet"
+        name: "op-faucet"
+        spec:
+          kind: "op-faucet"
+        deps:
+          nodes:
+            - "rpc-0"
+
+      - kind: "flashblocks-websocket-proxy"
+        name: "fb-ws-proxy"
+        spec:
+          kind: "flashblocks-websocket-proxy"
+        deps:
+          nodes:
+            - "seq-0"
+            - "seq-1"
+            - "seq-2"

--- a/dev/karst-u19-beta/manifest.yaml
+++ b/dev/karst-u19-beta/manifest.yaml
@@ -1,0 +1,92 @@
+name: karst-u19-beta
+type: betanet
+status: pending
+deployed_on: ""
+description: |
+  * Karst U19 Betanet
+    * Jovian activated at genesis
+    * karst-u19-beta-0: permissioned fault proofs
+    * karst-u19-beta-1: permissionless fault proofs (fp-permissionless)
+    * Fresh replacement for u19-beta
+metadata:
+  domain: op-enterprise
+  team: core
+  tenant_id: karst-u19-beta
+  tenant_name: karst-u19-beta
+  tier_id: "100"
+  features:
+    mission_critical: false
+features:
+  - p2p-cluster-local
+  - gateway-api
+  - service-mesh
+cluster:
+    name: oplabs-dev-ent-networks-us-ue1-0
+l1:
+  name: sepolia
+  chain_id: 11155111
+l2:
+  deployment:
+    op-deployer:
+        version: 0.6.0-rc.3
+    fund_dev_accounts: false
+    overrides:
+      l2GenesisJovianTimeOffset: "0x0"
+      l2GenesisKarstTimeOffset: "0x8ca0" # 36000s = 10h after L2 genesis (deploy) time
+    gas_limit: 60000000
+    superchain_roles:
+      superchain_proxy_admin_owner: "0x8E851F7d8bAeaD95F592847a020cAC7A062dafd9"
+      protocol_versions_owner: "0x8E851F7d8bAeaD95F592847a020cAC7A062dafd9"
+      superchain_guardian: "0x8E851F7d8bAeaD95F592847a020cAC7A062dafd9"
+  components:
+    flashblocks-websocket-proxy:
+        version: flashblocks-websocket-proxy/v0.7.4
+    kona-node:
+        version: kona-node/v1.5.2
+    op-batcher:
+        version: op-batcher/v1.16.9
+    op-conductor:
+        version: op-conductor/v0.9.4
+    op-conductor-mon:
+        version: op-conductor-mon/v0.0.5
+    op-conductor-ops:
+        version: op-conductor-ops/v0.0.2
+    op-geth:
+        version: op-geth/v1.101702.1
+    op-interop-filter:
+        version: op-interop-filter/v0.2.0-rc.1
+    op-node:
+        version: op-node/v1.18.2
+    op-program:
+        version: op-program/v1.9.0-rc.1
+    op-rbuilder:
+        version: op-rbuilder/v0.3.2-rc5
+    op-reth:
+        version: op-reth/v2.2.3
+    op-supernode:
+        version: op-supernode/v0.3.1-rc.1
+    peer-mgmt-service:
+        version: peer-mgmt-service/v0.0.4
+    proxyd:
+        version: proxyd/v4.27.1
+    rollup-boost:
+        version: rollup-boost/v0.7.11
+  charts: {}
+  chains:
+    - name: karst-u19-beta-0
+      chain_id: "420110023"
+      features: []
+      deployment:
+        roles:
+          l1_proxy_admin_owner: "0x8E851F7d8bAeaD95F592847a020cAC7A062dafd9"
+          l2_proxy_admin_owner: "0x9F961F7d8BAEAd95f592847a020cAC7A062Dc0EA"
+    - name: karst-u19-beta-1
+      chain_id: "420110024"
+      features:
+        - fp-permissionless
+      deployment:
+        roles:
+          l1_proxy_admin_owner: "0x8E851F7d8bAeaD95F592847a020cAC7A062dafd9"
+          l2_proxy_admin_owner: "0x9F961F7d8BAEAd95f592847a020cAC7A062Dc0EA"
+workflow:
+  disable_k8s_merge: true


### PR DESCRIPTION
## Summary
New **U19 betanet** (`karst-u19-beta`), a fresh replacement for the broken `u19-beta` network. Scaffolded via the `just`/cookiecutter betanet preset per the [Self-Serve Devnets guide](https://www.notion.so/2a3f153ee1628069bd78f455ec021436), then customized.

## Config
- `type: betanet`, `status: pending`, cluster `oplabs-dev-ent-networks-us-ue1-0`
- op-deployer `0.6.0-rc.3`
- **Hardforks**: Jovian at genesis (`l2GenesisJovianTimeOffset: "0x0"`); **Karst activates 10h after genesis** (`l2GenesisKarstTimeOffset: "0x8ca0"` = 36000s offset, added to L2 genesis time)
- Two chains:
  | Chain | chain_id | Fault proofs |
  |---|---|---|
  | `karst-u19-beta-0` | `420110023` | permissioned |
  | `karst-u19-beta-1` | `420110024` | permissionless (`fp-permissionless`) |
- **Ownership** (modern non-deprecated fields):
  - `superchain_roles` + per-chain `l1_proxy_admin_owner` → `0x8E851F7d8bAeaD95F592847a020cAC7A062dafd9`
  - per-chain `l2_proxy_admin_owner` → `0x9F961F7d8BAEAd95f592847a020cAC7A062Dc0EA` (L1→L2 alias of the L1 PAO)
- **All sequencers on op-reth** (3 sequencers/chain); rpc/sync nodes keep a geth/reth mix

> [!NOTE]
> The `...TimeOffset` field is a **genesis-relative offset in seconds** (verified against op-deployer's `offsetToUpgradeTime` and a deployed network), not an absolute timestamp. Karst therefore fires 10h after this network's actual deploy/genesis time.

Chain IDs recorded in the Devnet Naming List.

🤖 Generated with [Claude Code](https://claude.com/claude-code)