### PR TITLE
chore: fix u19 statuses + remove service-mesh from karst networks

### DIFF
--- a/betanets/u19-beta/manifest.yaml
+++ b/betanets/u19-beta/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-beta
 type: betanet
 scope: https://github.com/ethereum-optimism/devnets/issues/316
-status: online
+status: offline
 description: |
     * U19 Betanet
       * Osaka on L2

--- a/dev/karst-u19-alpha/manifest.yaml
+++ b/dev/karst-u19-alpha/manifest.yaml
@@ -19,7 +19,6 @@ metadata:
 features:
   - p2p-cluster-local
   - gateway-api
-  - service-mesh
 cluster:
     name: oplabs-dev-ent-networks-us-ue1-0
 l1:

--- a/dev/karst-u19-beta/manifest.yaml
+++ b/dev/karst-u19-beta/manifest.yaml
@@ -19,7 +19,6 @@ metadata:
 features:
   - p2p-cluster-local
   - gateway-api
-  - service-mesh
 cluster:
     name: oplabs-dev-ent-networks-us-ue1-0
 l1:

--- a/dev/u19-alpha/manifest.yaml
+++ b/dev/u19-alpha/manifest.yaml
@@ -1,7 +1,7 @@
 name: u19-alpha
 type: alphanet
 scope: https://github.com/ethereum-optimism/devnets/issues/339
-status: online
+status: offline
 description: |
     * U19 Alphanet
       * Osaka on L2


### PR DESCRIPTION
## Summary
Unblocks the `devnets-pr` validation that was failing across PRs (#350, #351, this one). Two distinct issues, both surfaced once the karst networks deployed:

### 1. Stale statuses (manifest says online, live state offline)
```
invalid state transition: "<net>" status is offline but manifest has status online
```
- `dev/u19-alpha/manifest.yaml`: `online` → `offline`
- `betanets/u19-beta/manifest.yaml`: `online` → `offline`

### 2. Invalid `service-mesh` feature on the karst networks
The cookiecutter preset added `service-mesh` by default, which **requires** `port-migration` + `app-protocol` (Istio sidecar injection) — the preset omitted those companions:
```
feature "service-mesh" requires feature "port-migration" to also be enabled
feature "service-mesh" requires feature "app-protocol" to also be enabled
```
No other devnet uses `service-mesh`; removed it from both `dev/karst-u19-alpha` and `dev/karst-u19-beta`.

## Follow-up
After merge, the netchef artifact PRs **#350** (karst-u19-beta) and **#351** (karst-u19-alpha) need to be rebased onto `main`; their netchef-regenerated manifests still contain `service-mesh`, so that'll be removed there too during the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)