### PR TITLE
feat(karst-u19-beta): enable historical proofs on chain-1 rpc-1

### DIFF
--- a/dev/karst-u19-beta/inventory.yaml
+++ b/dev/karst-u19-beta/inventory.yaml
@@ -309,6 +309,12 @@ chains:
             kind: "op-reth"
             spec:
               kind: "archive"
+            values:
+              op-reth:
+                env:
+                  RETH_HISTORICAL_PROOFS_ENABLED: "true"
+                  RETH_HISTORICAL_PROOFS_V2: "true"
+                  RETH_HISTORICAL_PROOFS_PRUNE_DEPTH: "2419200"
           cl:
             kind: "op-node"
 


### PR DESCRIPTION
Enables `--proofs-history` (v2) on `karst-u19-beta-1` chain's `rpc-1` archive node, providing a 28-day historical proof window suitable for permissionless fault proof lookback.

### Changes

Adds `values.op-reth.env` block under chain-1's `rpc-1` node in `dev/karst-u19-beta/inventory.yaml`:

```yaml
RETH_HISTORICAL_PROOFS_ENABLED: "true"
RETH_HISTORICAL_PROOFS_V2: "true"
RETH_HISTORICAL_PROOFS_PRUNE_DEPTH: "2419200"  # 28 days
```

### Why

Permissionless chains need ~28 days of proof lookback. `--rpc.eth-proof-window` becomes too slow and memory-hungry at that range, so this switches the archive node to `--proofs-history` (v2) which is designed for that window.

### Scope

- Only affects chain-1's `rpc-1` archive node (the proof oracle target)
- Chain-0 and chain-1's other nodes are untouched
- Pod will re-init the historical proofs db on restart