### PR TITLE
karst-u19: update rollup-boost

### DIFF
--- a/dev/karst-u19-alpha/manifest.yaml
+++ b/dev/karst-u19-alpha/manifest.yaml
@@ -82,7 +82,7 @@ l2:
         proxyd:
             version: proxyd/v4.27.4
         rollup-boost:
-            version: rollup-boost/v0.7.11
+            version: rollup-boost/v0.7.15
     chains:
         - name: karst-u19-alpha-0
           chain_id: "420100010"

--- a/dev/karst-u19-beta/manifest.yaml
+++ b/dev/karst-u19-beta/manifest.yaml
@@ -83,7 +83,7 @@ l2:
         proxyd:
             version: proxyd/v4.27.4
         rollup-boost:
-            version: rollup-boost/v0.7.11
+            version: rollup-boost/v0.7.15
     chains:
         - name: karst-u19-beta-0
           chain_id: "420110023"


### PR DESCRIPTION
Aiming to fix Payload ID mismatches on alphanet