### PR TITLE
karst-u19: Configure fault proofs for kona

### DIFF
--- a/dev/karst-u19-alpha/manifest.yaml
+++ b/dev/karst-u19-alpha/manifest.yaml
@@ -101,6 +101,8 @@ l2:
           chain_id: "420100011"
           features:
             - fp-permissionless
+            - kona
+            - fp-kona
           deployment:
             overrides: {}
             gas_limit: 60000000

--- a/dev/karst-u19-beta/manifest.yaml
+++ b/dev/karst-u19-beta/manifest.yaml
@@ -102,6 +102,8 @@ l2:
           chain_id: "420110024"
           features:
             - fp-permissionless
+            - kona
+            - fp-kona
           deployment:
             overrides: {}
             gas_limit: 60000000


### PR DESCRIPTION
This PR fixes an issue where op-challenger and op-proposer were not configured for `CANNON_KONA` on the karst-u19 devnets.