### PR TITLE
karst-u19: netchef re-trigger

### DIFF
--- a/dev/karst-u19-alpha/inventory.yaml
+++ b/dev/karst-u19-alpha/inventory.yaml
@@ -356,6 +356,7 @@ chains:
           values:
             op-reth:
               env:
+                # Useless comment to trigger a rerun alpha UpdateNetwork after previous manifest push race
                 RETH_HISTORICAL_PROOFS_ENABLED: "true"
                 RETH_HISTORICAL_PROOFS_V2: "true"
                 RETH_HISTORICAL_PROOFS_PRUNE_DEPTH: "2419200"


### PR DESCRIPTION
Re-trigger the netchef workflow for karst-alpha. A prior devnet run failed because, I suspect, both beta and alpha networks were updated in the same PR. And netchef can't handle that.