### PR TITLE
feat(karst-u19-beta): enable flashblocks on chain-1 sequencers

### DIFF
--- a/dev/karst-u19-beta/inventory.yaml
+++ b/dev/karst-u19-beta/inventory.yaml
@@ -267,6 +267,13 @@ chains:
               kind: "full"
           cl:
             kind: "op-node"
+          builder:
+            kind: "op-rbuilder"
+          flashblocks:
+            builder:
+              kind: "op-rbuilder"
+            rollup-boost:
+              kind: "rollup-boost"
 
       - kind: "node"
         name: "seq-1"
@@ -278,6 +285,13 @@ chains:
               kind: "full"
           cl:
             kind: "op-node"
+          builder:
+            kind: "op-rbuilder"
+          flashblocks:
+            builder:
+              kind: "op-rbuilder"
+            rollup-boost:
+              kind: "rollup-boost"
 
       - kind: "node"
         name: "seq-2"
@@ -289,6 +303,13 @@ chains:
               kind: "full"
           cl:
             kind: "op-node"
+          builder:
+            kind: "op-rbuilder"
+          flashblocks:
+            builder:
+              kind: "op-rbuilder"
+            rollup-boost:
+              kind: "rollup-boost"
 
       - kind: "node"
         name: "rpc-0"


### PR DESCRIPTION
## Problem

`karst-u19-beta-1` is not running flashblocks, even though it was intended to (its sibling `karst-u19-beta-0` runs them, and the network's shared `components` block pins `op-rbuilder`, `rollup-boost`, and `flashblocks-websocket-proxy`).

**Root cause:** in `dev/karst-u19-beta/inventory.yaml`, chain-1's three sequencers (`seq-0/1/2`) are missing the `builder` and `flashblocks` stanzas that chain-0's sequencers have. Without them, netchef never generates `op-rbuilder` / `rollup-boost`, never sets `op-node.rollupBoost.enabled`, and leaves `op-conductor` pointed straight at `op-reth`. This has been the case since the network was created in #349 — it was never configured, not removed.

Two leftover signals confirm this was an authoring omission rather than intent:
- chain-1 already declares `values.op-rbuilder.persistentVolume: 64Gi`, and
- chain-1 already declares the `fb-ws-proxy` service (which currently has no flashblocks producers behind it).

The sibling network `karst-u19-alpha` has the flashblocks stanzas on **both** chains, so the intended pattern is "every sequencer builds flashblocks."

## Change

Add the `builder` + `flashblocks` stanzas to beta-1's `seq-0/1/2`, mirroring chain-0 exactly. No other inventory changes are needed (rbuilder volume values and the `fb-ws-proxy` service are already present).

## Deploy note

beta-1 is a **live** network. This switches its sequencers' block-production path from direct `op-node → op-reth` to going through `rollup-boost`. The rollout should be coordinated (ideally one op-conductor member at a time), not synced blindly.

## Verification

- `yq` confirms all three beta-1 sequencers now resolve `spec.flashblocks != null`.
- YAML parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)