### PR TITLE
chore: enable historical proofs v2 on interop-jnt-v3-1

### DIFF
--- a/dev/interop-jnt-v3/inventory.yaml
+++ b/dev/interop-jnt-v3/inventory.yaml
@@ -320,6 +320,7 @@ chains:
                       memory: 4Gi
               env:
                   RETH_HISTORICAL_PROOFS_ENABLED: "true"
+                  RETH_HISTORICAL_PROOFS_V2: "true"
           rollup-boost:
               env:
                   EXECUTION_MODE: "dry-run"


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
